### PR TITLE
Allow specification of G-code that is executed during tool-changes.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2001,6 +2001,12 @@
   #if ENABLED(TOOLCHANGE_NO_RETURN)
     //#define EVENT_GCODE_AFTER_TOOLCHANGE "G12X"   // Extra G-code to run after tool-change
   #endif
+  /**
+   * Extra G-code to run while executing tool-change commands. Can be used to use an additional
+   * stepper motor (I axis, see option LINEAR_AXES in Configuration.h) to drive the tool-changer.
+   */
+  //#define EVENT_GCODE_TOOLCHANGE_T0 "G28 I\nG1 I0" // Extra G-code to run while executing tool-change command T0
+  //#define EVENT_GCODE_TOOLCHANGE_T1 "G1 I10"       // Extra G-code to run while executing tool-change command T1
 
   /**
    * Retract and prime filament on tool-change to reduce

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -57,7 +57,7 @@
   uint8_t singlenozzle_fan_speed[EXTRUDERS];
 #endif
 
-#if ENABLED(MAGNETIC_PARKING_EXTRUDER) || defined(EVENT_GCODE_AFTER_TOOLCHANGE) || (ENABLED(PARKING_EXTRUDER) && PARKING_EXTRUDER_SOLENOIDS_DELAY > 0)
+#if ENABLED(MAGNETIC_PARKING_EXTRUDER) || defined(EVENT_GCODE_TOOLCHANGE_T0) || defined(EVENT_GCODE_TOOLCHANGE_T1)|| defined(EVENT_GCODE_AFTER_TOOLCHANGE) || (ENABLED(PARKING_EXTRUDER) && PARKING_EXTRUDER_SOLENOIDS_DELAY > 0)
   #include "../gcode/gcode.h"
 #endif
 
@@ -1188,6 +1188,18 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     #endif
 
     TERN_(HAS_FANMUX, fanmux_switch(active_extruder));
+
+    #ifdef EVENT_GCODE_TOOLCHANGE_T0
+      if ((!no_move) && (new_tool == 0)) {
+        gcode.process_subcommands_now_P(PSTR(EVENT_GCODE_TOOLCHANGE_T0));
+      }
+    #endif
+
+    #ifdef EVENT_GCODE_TOOLCHANGE_T1
+      if ((!no_move) && (new_tool == 1)) {
+        gcode.process_subcommands_now_P(PSTR(EVENT_GCODE_TOOLCHANGE_T1));
+      }
+    #endif
 
     #ifdef EVENT_GCODE_AFTER_TOOLCHANGE
       if (!no_move && TERN1(DUAL_X_CARRIAGE, dual_x_carriage_mode == DXC_AUTO_PARK_MODE))


### PR DESCRIPTION
Adds options EVENT_GCODE_TOOLCHANGE_T0 (executed during T0) and
EVENT_GCODE_TOOLCHANGE_T1 (executed during T1)

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

This adds support for distinct event G-code scripts that are executed during tool change commands T0 and T1, respectively.

### Benefits

With this you can use an additional stepper motor (I axis) to drive the tool-changer. Can also be used to specify a nozzle cleaning routine for T0 that is different from the routine executed during T1. 

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

https://github.com/DerAndere1/Marlin/issues/40